### PR TITLE
Better handling of screen scaling

### DIFF
--- a/Metrician.App/Metrician.App.csproj
+++ b/Metrician.App/Metrician.App.csproj
@@ -7,6 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
     <!-- The .exe's icon (taskbar, Alt-Tab thumbnail, file-explorer thumbnail,
          shortcut icon).  The same file is also embedded below so each Form
          can set its own .Icon at runtime. -->
@@ -24,10 +25,6 @@
     <ProjectReference Include="..\Metrician.Library.Bridge\Metrician.Library.Bridge.csproj" />
     <ProjectReference Include="..\Metrician.Model.Graph\Metrician.Model.Graph.csproj" />
     <ProjectReference Include="..\Metrician.Presentation.Graph\Metrician.Presentation.Graph.csproj" />
-    <!-- Build-only dependency: Geometry is loaded at runtime from the Plugins
-         folder, not compiled into the host. The reference exists so the
-         solution build orders Geometry before App and the plugin DLL is
-         present when the app runs. -->
     <ProjectReference Include="..\Metrician.Nodes.Geometry\Metrician.Nodes.Geometry.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <Private>false</Private>

--- a/Metrician.Model.Graph/GraphPresenter.cs
+++ b/Metrician.Model.Graph/GraphPresenter.cs
@@ -13,6 +13,7 @@ namespace Metrician.Model.Graph
 
         private Vector2 _pan = Vector2.Zero;
         private float _zoom = 1f;
+        private float _dpiScale = 1f;
         private NodeId? _selectedNode;
         private PinId? _selectedPin;
 
@@ -37,6 +38,7 @@ namespace Metrician.Model.Graph
         public LayoutMetrics Metrics => _metrics;
         public Vector2 Pan => _pan;
         public float Zoom => _zoom;
+        public float DpiScale => _dpiScale;
         public NodeId? SelectedNode => _selectedNode;
         public PinId? SelectedPin => _selectedPin;
 
@@ -45,17 +47,30 @@ namespace Metrician.Model.Graph
         public event EventHandler<PinId?>? PinSelectionChanged;
         public event EventHandler<(NodeId Id, INodeTemplate Template)>? NodeSpawned;
 
-        public Vector2 ScreenToCanvas(Vector2 screen) =>
-            new((screen.X - _pan.X) / _zoom, (screen.Y - _pan.Y) / _zoom);
+        public Vector2 ScreenToCanvas(Vector2 screen)
+        {
+            float s = _zoom * _dpiScale;
+            return new((screen.X - _pan.X) / s, (screen.Y - _pan.Y) / s);
+        }
 
-        public Vector2 CanvasToScreen(Vector2 canvas) =>
-            new(canvas.X * _zoom + _pan.X, canvas.Y * _zoom + _pan.Y);
+        public Vector2 CanvasToScreen(Vector2 canvas)
+        {
+            float s = _zoom * _dpiScale;
+            return new(canvas.X * s + _pan.X, canvas.Y * s + _pan.Y);
+        }
 
         public void ApplyView(Vector2 pan, float zoom)
         {
             if (_pan == pan && _zoom == zoom) return;
             _pan = pan;
             _zoom = zoom;
+            Raise();
+        }
+
+        public void SetDpiScale(float dpiScale)
+        {
+            if (dpiScale <= 0f || MathF.Abs(_dpiScale - dpiScale) < 1e-6f) return;
+            _dpiScale = dpiScale;
             Raise();
         }
 

--- a/Metrician.Presentation.Graph/GraphControl.cs
+++ b/Metrician.Presentation.Graph/GraphControl.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Drawing.Drawing2D;
+using System.Drawing.Text;
 using System.Numerics;
 using Metrician.Core.Graph;
 using Metrician.Model.Graph;
@@ -53,6 +54,14 @@ namespace Metrician.Presentation.Graph
             Presenter.ViewChanged += (_, _) => Invalidate();
             Mouse.Changed += OnMouseChanged;
             Mouse.ContextMenuRequested += OnContextMenuRequested;
+
+            Presenter.SetDpiScale(DeviceDpi / 96f);
+        }
+
+        protected override void OnDpiChangedAfterParent(EventArgs e)
+        {
+            base.OnDpiChangedAfterParent(e);
+            Presenter.SetDpiScale(DeviceDpi / 96f);
         }
 
         protected override void OnPaint(PaintEventArgs e)
@@ -60,12 +69,14 @@ namespace Metrician.Presentation.Graph
             base.OnPaint(e);
             var g = e.Graphics;
             g.SmoothingMode = SmoothingMode.AntiAlias;
+            g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
 
             var saved = g.Save();
             try
             {
+                float s = Presenter.Zoom * Presenter.DpiScale;
                 g.TranslateTransform(Presenter.Pan.X, Presenter.Pan.Y);
-                g.ScaleTransform(Presenter.Zoom, Presenter.Zoom);
+                g.ScaleTransform(s, s);
                 _painter.DrawAll(g, Presenter, Mouse.State);
             }
             finally

--- a/Metrician.Presentation.Graph/GraphPainter.cs
+++ b/Metrician.Presentation.Graph/GraphPainter.cs
@@ -62,7 +62,7 @@ namespace Metrician.Presentation.Graph
                 g.DrawPath(border, path);
 
             using (var titleBrush = new SolidBrush(_theme.Text))
-            using (var titleFont = new Font(_theme.FontFamily, 9f, FontStyle.Bold))
+            using (var titleFont = new Font(_theme.FontFamily, 12f, FontStyle.Bold, GraphicsUnit.Pixel))
             {
                 var titleSize = g.MeasureString(node.Title, titleFont);
                 float titleX = rect.X + (rect.Width - titleSize.Width) / 2f;
@@ -89,7 +89,7 @@ namespace Metrician.Presentation.Graph
             }
 
             using var labelBrush = new SolidBrush(_theme.Text);
-            using var labelFont = new Font(_theme.FontFamily, 8f);
+            using var labelFont = new Font(_theme.FontFamily, 10.67f, FontStyle.Regular, GraphicsUnit.Pixel);
 
             var selectedPin = p.SelectedPin;
 
@@ -118,7 +118,7 @@ namespace Metrician.Presentation.Graph
                     pos.X - m.PinRadius - sz.Width - 4, pos.Y - 7);
             }
 
-            using var footerFont = new Font(_theme.FontFamily, 7.5f, FontStyle.Italic);
+            using var footerFont = new Font(_theme.FontFamily, 10f, FontStyle.Italic, GraphicsUnit.Pixel);
             using var footerBrush = new SolidBrush(_theme.FooterText);
             string footerText = $"by {node.Vendor}";
             var footerSize = g.MeasureString(footerText, footerFont);


### PR DESCRIPTION
## Summary
The node graph rendered poorly at Windows display scaling above 100%. The
host app didn't opt into a DPI mode, so the OS bitmap-stretched the window,
and the painter's hardcoded pen widths and point-sized fonts didn't track
DPI changes when the window moved between monitors.

This change makes the host PerMonitorV2-aware and threads a DPI scale
through the graph's render and hit-test pipeline.

## Changes

- `Metrician.App.csproj`: declares
  `<ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>` so
  `ApplicationConfiguration.Initialize()` enables the right mode at
  startup.
- `GraphPresenter`: gains a `DpiScale` (default 1) and a
  `SetDpiScale(...)` setter. `ScreenToCanvas` and `CanvasToScreen` now go
  through `zoom * dpiScale`. Pan stays in screen pixels (matches
  `MouseEventArgs`).
- `GraphControl`: calls `Presenter.SetDpiScale(DeviceDpi / 96f)` after
  construction and overrides `OnDpiChangedAfterParent` to keep the
  presenter in sync when the window crosses monitors. `OnPaint` applies
  `zoom * dpiScale` in its `ScaleTransform` and sets
  `TextRenderingHint.ClearTypeGridFit`.
- `GraphPainter`: the three painter fonts (title, label, footer) switch to
  `GraphicsUnit.Pixel`, with sizes converted from point-equivalent at 96
  DPI (9 pt becomes 12 px, 8 pt becomes 10.67 px, 7.5 pt becomes 10 px).
  This avoids double-scaling: point-sized fonts already multiply by
  `Graphics.DpiY`, and we want the scale-transform to be the single source
  of DPI scaling for the painter.

`LayoutMetrics` and pen widths are unchanged. They live inside the scaled
transform, so they pick up the DPI multiplier for free. The PropertyPane
and other WinForms-laid-out children are unchanged; the framework handles
their scaling under PerMonitorV2.